### PR TITLE
Add Config, /treepers reload and Changed ExplosionEvent.Denote to ExplosionEvent.Pre

### DIFF
--- a/src/main/java/org/knechtcraft/sponge/treepers/Config.java
+++ b/src/main/java/org/knechtcraft/sponge/treepers/Config.java
@@ -1,0 +1,24 @@
+package org.knechtcraft.sponge.treepers;
+
+import ninja.leaping.configurate.objectmapping.ObjectMapper;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.Setting;
+
+public class Config {
+
+    public final static ObjectMapper<Config> MAPPER;
+
+    static  {
+        try {
+            MAPPER = ObjectMapper.forClass(Config.class);
+        } catch (ObjectMappingException e) {
+            throw new ExceptionInInitializerError("Couldn't initialize ObjectMapper for Config");
+        }
+    }
+
+    @Setting(value = "BreakBlocks", comment = "Should the creeper explosion break blocks.")
+    public boolean BREAK_BLOCKS = false;
+
+    @Setting(value = "PlantTree", comment = "Should the creeper explosion plant a tree.")
+    public boolean PLANT_TREE = true;
+}

--- a/src/main/java/org/knechtcraft/sponge/treepers/Config.java
+++ b/src/main/java/org/knechtcraft/sponge/treepers/Config.java
@@ -21,4 +21,8 @@ public class Config {
 
     @Setting(value = "PlantTree", comment = "Should the creeper explosion plant a tree.")
     public boolean PLANT_TREE = true;
+
+    @Setting(value = "ShowParticles", comment = "Should the explosion particles been shown. (NOTE: It seems that the methods provided in Sponge "
+            + "don't work yet)")
+    public boolean SHOW_PARTICLES = true;
 }

--- a/src/main/java/org/knechtcraft/sponge/treepers/Treepers.java
+++ b/src/main/java/org/knechtcraft/sponge/treepers/Treepers.java
@@ -2,11 +2,10 @@ package org.knechtcraft.sponge.treepers;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.google.inject.Inject;
-import com.sun.istack.internal.logging.Logger;
-import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.slf4j.Logger;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.config.DefaultConfig;
@@ -49,7 +48,7 @@ public class Treepers {
         try {
             config = Config.MAPPER.bindToNew().populate(configLoader.load());
         } catch (ObjectMappingException e) {
-            logger.severe("Couldn't populate Config!", e);
+            logger.error("Couldn't populate Config!", e);
         }
     }
 


### PR DESCRIPTION
Additions:
- Config
  - BreakBlocks: If true, creeper explosion breaks blocks
  - PlantTree: If true, plants a tree at the origin point of the creeper explosion
  - ShowParticles: If true, shows the explosions particles from he creeper explosion (Note: The method provided to do this in Sponge doesn't seem to be working)
- /treepers reload command
  - Reloads the config

Changes:
- Changed ExplosionEvent.Denote to ExplosionEvent.Pre
  - In my test server, you can't cancel ExplosionEvent.Denote. To fix this I changed the event to be ExplosionEvent.Pre because this event happens before the explosion.
